### PR TITLE
AM9:00 前に前日に打刻されてしまうバグを修正

### DIFF
--- a/src/main/MiterasClient.ts
+++ b/src/main/MiterasClient.ts
@@ -47,7 +47,7 @@ export default class MiterasClient {
   // 現在の日付を yyyy-mm-dd 形式で取得
   private getCurrentDate(): string {
     const date = new Date()
-    return date.toISOString().split('T')[0]
+    return `${date.getFullYear()}-${date.getMonth() + 1}-${date.getDate()}`
   }
 
   // ログインページのcsrfトークンを取得


### PR DESCRIPTION
## issue

- fix: https://github.com/ttsukasan/mitelecton/issues/2

## 修正内容

getCurrentDate メソッドで、UTC に依存しない `yyyy-mm-dd` を取得できるように修正しました。

## 詳細

出社打刻の処理では workDateString に打刻対象の日付を yyyy-mm-dd 形式で設定しています。 この値は getCurrentDate メソッドによって取得されます。

getCurrentDate メソッドでは `Date.prototype.toISOString` で取得した文字列から `T` 以降を取り除くことで `yyyy-mm-dd` の日付を取得していました。 `Date.prototype.toISOString` のタイムゾーンは常に 0 UTC オフセットになっているため、UTC+9:00 になっている日本時間では AM9:00 前に getCurrentDate メソッドを実行すると前日の日付が取得できる状態でした。